### PR TITLE
Update regenerator to latest master version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "ecmarkup": "^1.2.1",
     "q": "*",
-    "regenerator": "git://github.com/facebook/regenerator#async-await",
+    "regenerator": "^0.8.34",
     "request": "*"
   },
   "repository": {


### PR DESCRIPTION
The support for `async` functions and `await` expressions has been on by default for many months now.
