### PR TITLE
Fix various issues and add missing semantics.

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -20,8 +20,8 @@
       1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
       1. If _result_.[[type]] is ~normal~, let _completionResult_ be Call(_promiseCapability_.[[Resolve]], *undefined*, «*undefined*»).
       1. Otherwise, if _result_.[[type]] is ~return~, let _completionResult_ be Call(_promiseCapability_.[[Resolve]], *undefined*, «_result_.[[value]]»).
-      1. Otherwise, _result_.[[type]] must be ~throw~. Let _completionResult_ be Call(_promiseCapability_.[[Reject]], *undefined*, «_result_.[[value]]»)
-      1. If _completionResult_ is an abrupt completion, return _completionResult_.
+      1. Otherwise, _result_.[[type]] must be ~throw~. Let _completionResult_ be Call(_promiseCapability_.[[Reject]], *undefined*, «_result_.[[value]]»).
+      1. ReturnIfAbrupt(_completionResult_).
     </emu-alg>
   </emu-clause>
 
@@ -31,14 +31,14 @@
       1. Let _asyncContext_ be the running execution context.
       1. Assert: _asyncContext_ is the execution context of an async function.
       1. Let _promiseCapability_ be NewPromiseCapability(%Promise%).
-      1. ReturnIfAbrupt(_promiseCapability_).
+      1. Assert: _promiseCapability_ is not an abrupt completion. <!-- TODO: Either remove this assertion or add after every call to NewPromiseCapability(%Promise%). -->
       1. Let _resolveResult_ be Call(_promiseCapability_.[[Resolve]], *undefined*, «_value_»).
       1. ReturnIfAbrupt(_resolveResult_).
       1. Let _onFulfilled_ be a new built-in function object as defined in <a href="#async-function-definitions-awaited-fulfilled">AsyncFunction Awaited Fulfilled</a>.
       1. Let _onRejected_ be a new built-in function object as defined in <a href="#async-function-definitions-awaited-rejected">AsyncFunction Awaited Rejected</a>.
       1. Set _onFulfilled_ and _onRejected_'s [[AsyncContext]] internal slots to _asyncContext_.
       1. Let _throwawayCapability_ be NewPromiseCapability(%Promise%). <!-- Kind of lame. This is the equivalent of ignoring the return value -->
-      1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_, _throwawayCapability_).
+      1. Perform PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
       1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
       1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
         1. Return _resumptionValue_.
@@ -58,8 +58,9 @@
       1. Let _prevContext_ be the running execution context.
       1. Suspend _prevContext_.
       1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-      1. Resume the suspended evaluation of _asyncContext_ using NormalCompletion(_value_) as the result of the operation that suspended it.
+      1. Resume the suspended evaluation of _asyncContext_ using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
       1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+      1. Return Completion(_result_).
     </emu-alg>
   </emu-clause>
 
@@ -71,8 +72,9 @@
       1. Let _prevContext_ be the running execution context.
       1. Suspend _prevContext_.
       1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-      1. Resume the suspended evaluation of _asyncContext_ using Completion{[[type]]: ~throw~, [[value]]: _reason_, [[target]]: ~empty~} as the result of the operation that suspended it.
+      1. Resume the suspended evaluation of _asyncContext_ using Completion{[[type]]: ~throw~, [[value]]: _reason_, [[target]]: ~empty~} as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
       1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+      1. Return Completion(_result_).
     </emu-alg>
   </emu-clause>
 </emu-clause>

--- a/spec/arrows.html
+++ b/spec/arrows.html
@@ -9,51 +9,22 @@
     </ul>
     <p><emu-prodref name="AsyncArrowFunction" a="2" class="inline"></emu-prodref></p>
     <ul>
-      <li>It is a SyntaxError if the lexical token sequence matched by |CoverCallExpressionAndAsyncArrowHead| cannot be parsed with no tokens left over using |AsyncArrowHead| as the goal symbol.</li>
+      <li>It is a Syntax Error if the lexical token sequence matched by |CoverCallExpressionAndAsyncArrowHead| cannot be parsed with no tokens left over using |AsyncArrowHead| as the goal symbol.</li>
       <li>All Early Error rules for |AsyncArrowHead| and its derived productions apply to CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.</li>
     </ul>
     <p><emu-prodref name="AsyncArrowHead" class="inline"></emu-prodref></p>
     <ul>
-      <li>It is a SyntaxError if |ArrowFormalParameters| Contains |YieldExpression| is true.
-      <li>It is a SyntaxError if |ArrowFormalParameters| Contains |AwaitExpression| is true.
+      <li>It is a Syntax Error if |ArrowFormalParameters| Contains |YieldExpression| is *true*.
+      <li>It is a Syntax Error if |ArrowFormalParameters| Contains |AwaitExpression| is *true*.
       <li>It is a Syntax Error if any element of the BoundNames of |ArrowFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncConciseBody|.
     </ul>
-  </emu-clause>
-
-  <emu-clause id="async-arrows-static-semantics-LexicallyDeclaredNames">
-    <h1>Static Semantics: LexicallyDeclaredNames</h1>
-    <p><emu-prodref name="AsyncConciseBody" a="1"></emu-prodref></p>
-    <emu-alg>
-      1. Return an empty List.
-    </emu-alg>
   </emu-clause>
 
   <emu-clause id="async-arrows-static-semantics-CoveredAsyncArrowHead">
     <h1>Static Semantics: CoveredAsyncArrowHead</h1>
     <p><emu-prodref name="CoverCallExpressionAndAsyncArrowHead" class="inline"></emu-prodref></p>
     <emu-alg>
-      1. Return the result of parsing the lexical token stream matched by |CoverCallExpressionAndAsyncArrowHead|<sub>[Yield, Await]</sub> using either |AsyncArrowHead|, |AsyncArrowHead|<sub>[Yield]</sub>, |AsyncArrowHead|<sub>[Await]</sub>, or |AsyncArrowHead|<sub>[Yield, Await]</sub> as the goal symbol depending upon whether the <sub>[Yield]</sub> and <sub>[Await]</sub> grammar parameters were present when |CoverCallExpressionAndAsyncArrowHead| was matched.
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="async-arrows-static-semantics-BoundNames">
-    <h1>Static Semantics: BoundNames</h1>
-    <p><emu-prodref name="AsyncArrowFunction" a="1" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return the BoundNames of |AsyncArrowBindingIdentifier|.
-    </emu-alg>
-    <p><emu-prodref name="AsyncArrowFunction" a="2" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
-      1. Return the BoundNames of _head_.
-    </emu-alg>
-    <p><emu-prodref name="AsyncArrowBindingIdentifier" a="1" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return the BoundNames of |BindingIdentifier|.
-    </emu-alg>
-    <p><emu-prodref name="AsyncArrowHead" a="1" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return the BoundNames of |ArrowFormalParameters|.
+      1. Return the result of parsing the lexical token stream matched by |CoverCallExpressionAndAsyncArrowHead|<sub>[Yield, Await]</sub> using either |AsyncArrowHead| or |AsyncArrowHead|<sub>[Yield]</sub> as the goal symbol depending upon whether the <sub>[Yield]</sub> grammar parameter was present when |CoverCallExpressionAndAsyncArrowHead| was matched.
     </emu-alg>
   </emu-clause>
 
@@ -70,55 +41,24 @@
       1. If _symbol_ is not one of <emu-nt>NewTarget</emu-nt>, <emu-nt>SuperProperty</emu-nt>, <emu-nt>SuperCall</emu-nt>, <emu-t>super</emu-t>, or <emu-t>this</emu-t>, return *false*.
       2. Let _head_ be CoveredAsyncFunctionHead of |CoverCallExpressionAndAsyncArrowHead|.
       3. If _head_ Contains _symbol_ is *true*, return *true*.
-      4. return |AsyncConciseBody| Contains _symbol_.
+      4. Return |AsyncConciseBody| Contains _symbol_.
     </emu-alg>
     <emu-note>Normally, Contains does not look inside most function forms. However, Contains is used to detect `new.target`, `this`, and `super` usage within an AsyncArrowFunction.</emu-note>
-    <p><emu-prodref name="AsyncArrowHead" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return |ArrowFormalParameters| Contains _symbol_.
-    </emu-alg>
   </emu-clause>
 
   <emu-clause id="async-arrows-static-semantics-ContainsExpression">
     <h1>Static Semantics: ContainsExpression</h1>
-    <p><emu-prodref name="AsyncArrowFunction" a="1" class="inline"></emu-prodref></p>
+    <p><emu-prodref name="AsyncArrowBindingIdentifier" a="1" class="inline"></emu-prodref></p>
     <emu-alg>
       1. Return *false*.
-    </emu-alg>
-
-    <p><emu-prodref name="AsyncArrowFunction" a="2" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Let _head_ be CoveredAsyncFunctionHead of |CoverCallExpressionAndAsyncArrowHead|.
-      2. Return ContainsExpression of _head_.
-    </emu-alg>
-
-    <p><emu-prodref name="AsyncArrowHead" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return ContainsExpression of |ArrowFormalParameters|.
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="async-arrows-static-semantics-HasInitializer">
-    <h1>Static Semantics: HasInitializer</h1>
-    <p><emu-prodref name="AsyncArrowBindingIdentifier" class="inline" a="1"></emu-prodref></p>
-    <emu-alg>
-      1. Return *false*.
-    </emu-alg>
-    <p><emu-prodref name="AsyncArrowHead" class="inline" a="1"></emu-prodref></p>
-    <emu-alg>
-      1. Return HasInitializer of |ArrowFormalParameters|.
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="async-arrows-static-semantics-ExpectedArgumentCount">
     <h1>Static Semantics: ExpectedArgumentCount</h1>
-    <p><emu-prodref name="AsyncArrowBindingIdentifier" class="inline" a="1"></emu-prodref></p>
+    <p><emu-prodref name="AsyncArrowBindingIdentifier" a="1" class="inline"></emu-prodref></p>
     <emu-alg>
       1. Return *1*.
-    </emu-alg>
-    <p><emu-prodref name="AsyncArrowHead" class="inline" a="1"></emu-prodref></p>
-    <emu-alg>
-      1. Return HasInitializer of |ArrowFormalParameters|.
     </emu-alg>
   </emu-clause>
 
@@ -130,6 +70,82 @@
       1. Return *false*.
     </emu-alg>
   </emu-clause>
+
+  <emu-clause id="async-arrows-static-semantics-IsSimpleParameterList">
+    <h1>Static Semantics: IsSimpleParameterList</h1>
+    <p><emu-prodref name="AsyncArrowBindingIdentifier" a="1" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return *true*.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="async-arrows-static-semantics-LexicallyDeclaredNames">
+    <h1>Static Semantics: LexicallyDeclaredNames</h1>
+    <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return an empty List.
+    </emu-alg>
+    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return LexicallyDeclaredNames of |AsyncFunctionBody|.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="async-arrows-static-semantics-LexicallyScopedDeclarations">
+    <h1>Static Semantics: LexicallyScopedDeclarations</h1>
+    <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return an empty List.
+    </emu-alg>
+    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return LexicallyScopedDeclarations of |AsyncFunctionBody|.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="async-arrows-static-semantics-VarDeclaredNames">
+    <h1>Static Semantics: VarDeclaredNames</h1>
+    <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return an empty List.
+    </emu-alg>
+    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return VarDeclaredNames of |AsyncFunctionBody|.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="async-arrows-static-semantics-VarScopedDeclarations">
+    <h1>Static Semantics: VarScopedDeclarations</h1>
+    <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return an empty List.
+    </emu-alg>
+    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Return VarScopedDeclarations of |AsyncFunctionBody|.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="async-arrows-IteratorBindingInitialization">
+    <h1>Runtime Semantics: IteratorBindingInitialization</h1>
+    <p>With parameters _iteratorRecord_ and _environment_.</p>
+    <p><emu-prodref name="AsyncArrowBindingIdentifier" a="1" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. Assert: _iteratorRecord_.[[done]] is *false*.
+      1. Let _next_ be IteratorStep(_iteratorRecord_.[[iterator]]).
+      1. If _next_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
+      1. ReturnIfAbrupt(_next_).
+      1. If _next_ is *false*, set _iteratorRecord_.[[done]] to true.
+      1. Else
+        1. Let _v_ be IteratorValue(_next_).
+        1. If _v_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
+        1. ReturnIfAbrupt(_v_).
+      1. If _iteratorRecord_.[[done]] is *true*, let _v_ be *undefined*.
+      1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="async-arrows-EvaluateBody">
     <h1>Runtime Semantics: EvaluateBody</h1>
     <p>With parameter _functionObject_.</p>
@@ -152,7 +168,7 @@
       1. If the function code for this |AsyncArrowFunction| is strict mode code, let _strict_ be true. Otherwise, let _strict_ be false.
       2. Let _scope_ be the LexicalEnvironment of the running execution context.
       3. Let _parameters_ be |AsyncArrowBindingIdentifier|.
-      4. Let _closure_ be AsyncFunctionCreate(~Arrow~, _parameters_, |ConciseBody|, _scope_, _strict_).
+      4. Let _closure_ be AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
       5. Return _closure_.
     </emu-alg>
 
@@ -162,7 +178,7 @@
       2. Let _scope_ be the LexicalEnvironment of the running execution context.
       3. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
       4. Let _parameters_ be the |ArrowFormalParameters| production matched by _head_.
-      5. Let _closure_ be AsyncFunctionCreate(~Arrow~, _parameters_, |ConciseBody|, _scope_, _strict_).
+      5. Let _closure_ be AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
       6. Return _closure_.
     </emu-alg>
   </emu-clause>

--- a/spec/async-function-objects.html
+++ b/spec/async-function-objects.html
@@ -17,7 +17,7 @@
       <emu-alg>
           1. Let _C_ be the active function object.
           2. Let _args_ be the argumentsList that was passed to this function by [[Call]] or [[Construct]].
-          3. Return CreateDynamicFunction(_C_, NewTarget, "async", _args_)
+          3. Return CreateDynamicFunction(_C_, NewTarget, "async", _args_).
       </emu-alg>
 
       <emu-note>See note for 19.2.1.1</emu-note>
@@ -28,9 +28,9 @@
 
     <p>The AsyncFunction constructor is a standard built-in function object that inherits from the `Function` constructor. The value of the [[Prototype]] internal slot of the AsyncFunction constructor is the intrinsic object %Function%.
 
-    <p>The value of the [[Extensible]] internal slot of the AsyncFunction constructor is *true*
+    <p>The value of the [[Extensible]] internal slot of the AsyncFunction constructor is *true*.
 
-    <p>The value of the *name* property of the AsyncFunction is "AsyncFunction"
+    <p>The value of the *name* property of the AsyncFunction is "AsyncFunction".
 
     <p>The AsyncFunction constructor has the following properties:</p>
 

--- a/spec/declarations-and-expressions.html
+++ b/spec/declarations-and-expressions.html
@@ -6,7 +6,8 @@
     <p>
       <emu-prodref name="AsyncFunctionDeclaration" a="1" class="inline"></emu-prodref><br>
       <emu-prodref name="AsyncFunctionDeclaration" a="2" class="inline"></emu-prodref><br>
-      <emu-prodref name="AsyncFunctionExpression" a="1" class="inline"></emu-prodref>
+      <emu-prodref name="AsyncFunctionExpression" a="1" class="inline"></emu-prodref><br>
+      <emu-prodref name="AsyncFunctionExpression" a="2" class="inline"></emu-prodref>
     </p>
     <ul>
       <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.
@@ -15,6 +16,8 @@
       <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.
       <li>It is a Syntax Error if |FormalParameters| contains |SuperProperty| is *true*.
       <li>It is a Syntax Error if |AsyncFunctionBody| contains |SuperProperty| is *true*.
+      <li>It is a Syntax Error if |FormalParameters| contains |SuperCall| is *true*.
+      <li>It is a Syntax Error if |AsyncFunctionBody| contains |SuperCall| is *true*.
     </ul>
   </emu-clause>
 
@@ -28,7 +31,7 @@
     <emu-alg>
       1. Return «"*default*"».
     </emu-alg>
-    <emu-note>"*default*" is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</emu-note>
+    <emu-note>"`*default*`" is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</emu-note>
   </emu-clause>
   <emu-clause id="async-decls-exprs-static-semantics-Contains">
     <h1>Static Semantics: Contains</h1>
@@ -43,19 +46,6 @@
       1. Return *false*.
     </emu-alg>
     <emu-note>Could probably check if _symbol_ is one of these declarations or expressions, but this is not done in current spec and may not be necessary. See also: <a href="https://bugs.ecmascript.org/show_bug.cgi?id=4383">https://bugs.ecmascript.org/show_bug.cgi?id=4383</a>.</emu-note>
-  </emu-clause>
-  <emu-clause id="async-decls-exprs-static-semantics-HasDirectSuper">
-    <h1>Static Semantics: HasDirectSuper</h1>
-    <p>
-      <emu-prodref name="AsyncFunctionDeclaration" a="1" class="inline"></emu-prodref><br>
-      <emu-prodref name="AsyncFunctionDeclaration" a="2" class="inline"></emu-prodref><br>
-      <emu-prodref name="AsyncFunctionExpression" a="1" class="inline"></emu-prodref><br>
-      <emu-prodref name="AsyncFunctionExpression" a="2" class="inline"></emu-prodref><br>
-    </p>
-    <emu-alg>
-      1. If |FormalParameters| Contains |SuperCall| is *true*, return *true*.
-      2. Return |AsyncFunctionBody| Contains |SuperCall|.
-    </emu-alg>
   </emu-clause>
 
   <emu-clause id="async-decls-exprs-static-semantics-HasName">
@@ -77,7 +67,7 @@
       <emu-prodref name="AsyncFunctionDeclaration" a="2" class="inline"></emu-prodref>
     </p>
     <emu-alg>
-      1. Return *true*.
+      1. Return *false*.
     </emu-alg>
   </emu-clause>
 
@@ -114,6 +104,7 @@
 
   <emu-clause id="async-decls-exprs-EvaluateBody">
     <h1>Runtime Semantics: EvaluateBody</h1>
+    <p>With parameter _functionObject_.</p>
     <p>
       <emu-prodref name="AsyncFunctionBody" a="1" class="inline"></emu-prodref><br>
     </p>
@@ -128,12 +119,34 @@
     <h1>Runtime Semantics: Evaluation</h1>
     <p><emu-prodref name="AsyncFunctionDeclaration" a="1" class="inline"></emu-prodref></p>
     <emu-alg>
-      1. Return.
+      1. Return NormalCompletion(~empty~).
     </emu-alg>
 
     <p><emu-prodref name="AsyncFunctionDeclaration" a="2" class="inline"></emu-prodref></p>
     <emu-alg>
-      1. Return.
+      1. Return NormalCompletion(~empty~).
+    </emu-alg>
+
+    <p><emu-prodref name="AsyncFunctionExpression" a="1" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. If the function code for |AsyncFunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+      1. Let _scope_ be the LexicalEnvironment of the running execution context.
+      1. Let _closure_ be AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
+      1. Return _closure_.
+    </emu-alg>
+
+    <p><emu-prodref name="AsyncFunctionExpression" a="2" class="inline"></emu-prodref></p>
+    <emu-alg>
+      1. If the function code for |AsyncFunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+      1. Let _scope_ be the LexicalEnvironment of the running execution context.
+      1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
+      1. Let _envRec_ be _funcEnv_'s EnvironmentRecord.
+      1. Let _name_ be StringValue of |BindingIdentifier|.
+      1. Perform _envRec_.CreateImmutableBinding( _name_). <!-- FIXME: Remove the space before _name_ without breaking the result html. -->
+      1. Let _closure_ be AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _funcEnv_, _strict_).
+      1. Perform SetFunctionName(_closure_, _name_).
+      1. Perform _envRec_.InitializeBinding( _name_, _closure_).
+      1. Return _closure_.
     </emu-alg>
 
     <p><emu-prodref name="AwaitExpression" a="1" class="inline"></emu-prodref></p>

--- a/spec/methods.html
+++ b/spec/methods.html
@@ -43,10 +43,29 @@
   <emu-clause id="async-methods-static-semantics-PropName">
     <h1>Static Semantics: PropName</h1>
     <p>
-      <emu-prodref name="AsyncMethod" class="inline"></emu-prodref><br>
+      <emu-prodref name="AsyncMethod" class="inline"></emu-prodref>
     </p>
     <emu-alg>
       1. Return PropName of |PropertyName|.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="async-methods-PropertyDefinitionEvaluation">
+    <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
+    <p>With parameters _object_ and _enumerable_.</p>
+    <p>
+      <emu-prodref name="AsyncMethod" class="inline"></emu-prodref>
+    </p>
+    <emu-alg>
+      1. Let _propKey_ be the result of evaluating |PropertyName|.
+      1. ReturnIfAbrupt(_propKey_).
+      1. If the function code for this |AsyncMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+      1. Let _scope_ be the LexicalEnvironment of the running execution context.
+      1. Let _closure_ be AsyncFunctionCreate(~Method~, |StrictFormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
+      1. Perform MakeMethod(_closure_, _object_).
+      1. Perform SetFunctionName(_closure_, _propKey_).
+      1. Let _desc_ be the Property Descriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
+      1. Return DefinePropertyOrThrow(_object_, _propKey_, _desc_).
     </emu-alg>
   </emu-clause>
 </emu-clause>

--- a/spec/modified-productions.html
+++ b/spec/modified-productions.html
@@ -11,6 +11,56 @@
     </emu-production>
   </emu-clause>
 
+  <emu-clause id="ArrowFunction">
+    <h1>|ArrowFunction|</h1>
+    <emu-production name="ArrowFunction" params="Yield, Default, Await">
+      <emu-rhs><emu-nt params="?Yield, ?Await">ArrowParameters</emu-nt> <emu-gann>no <emu-nt>LineTerminator</emu-nt> here</emu-gann> => <emu-nt params="?In">ConciseBody</emu-nt></emu-rhs>
+    </emu-production>
+
+    <emu-clause id="arrow-function-static-semantics-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <p>
+        <emu-prodref name="ArrowFunction" class="inline"></emu-prodref>
+      </p>
+      <ul>
+        <li>It is a Syntax Error if |ArrowParameters| Contains |YieldExpression| is *true*.
+        <li><ins class="block">It is a Syntax Error if |ArrowParameters| Contains |AwaitExpression| is *true*.</ins>
+        <li>It is a Syntax Error if any element of the BoundNames of |ArrowParameters| also occurs in the LexicallyDeclaredNames of |ConciseBody|.
+      </ul>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="Identifiers">
+    <h1>|Identifiers|</h1>
+    <emu-production name="IdentifierReference" params="Yield, Await">
+      <emu-rhs a="identifier-reference"><emu-nt>Identifier</emu-nt></emu-rhs>
+      <emu-rhs a="identifier-reference-yield" constraints="~Yield">yield</emu-rhs>
+    </emu-production>
+
+    <emu-production name="BindingIdentifier" params="Yield, Await">
+      <emu-rhs a="binding-identifier"><emu-nt>Identifier</emu-nt></emu-rhs>
+      <emu-rhs a="binding-identifier-yield" constraints="~Yield">yield</emu-rhs>
+    </emu-production>
+
+    <emu-production name="LabelIdentifier" params="Yield, Await">
+      <emu-rhs a="label-identifier"><emu-nt>Identifier</emu-nt></emu-rhs>
+      <emu-rhs a="label-identifier-yield" constraints="~Yield">yield</emu-rhs>
+    </emu-production>
+
+    <emu-clause id="identifier-static-semantics-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <p>
+        <emu-prodref name="IdentifierReference" a="identifier-reference" class="inline"></emu-prodref><br>
+        <emu-prodref name="BindingIdentifier" a="binding-identifier" class="inline"></emu-prodref><br>
+        <emu-prodref name="LabelIdentifier" a="label-identifier" class="inline"></emu-prodref>
+      </p>
+      <ul>
+        <li>It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter and StringValue of |Identifier| is `"yield"`.
+        <li><ins class="block">It is a Syntax Error if this production has an <sub>[Await]</sub> parameter and StringValue of |Identifier| is `"await"`.</ins>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+
   <emu-clause id="PrimaryExpression">
     <h1>|PrimaryExpression|</h1>
     <emu-production name="PrimaryExpression" params="Yield, Await">
@@ -48,19 +98,58 @@
   <emu-clause id="UnaryExpression">
     <h1>|UnaryExpression|</h1>
     <emu-production name="UnaryExpression" params="Yield, Await">
-      <emu-rhs><emu-nt params="?Yield, ?Await">PostfixExpression</emu-nt></emu-rhs>
-      <emu-rhs>delete <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <emu-rhs>void <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <emu-rhs>typeof <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <emu-rhs>++ <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <emu-rhs>-- <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <emu-rhs>+ <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <emu-rhs>- <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <emu-rhs>~ <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
-      <ins class="block"><emu-rhs constraints="+Await"><emu-nt params="?Yield">AwaitExpression</emu-nt></emu-rhs></ins>
+      <emu-rhs a="unary-expression-postfix"><emu-nt params="?Yield, ?Await">PostfixExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-delete">delete <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-void">void <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-typeof">typeof <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-increment">++ <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-decrement">-- <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-positive">+ <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-negative">- <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-bitwise-complement">~ <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <emu-rhs a="unary-expression-logical-complement">! <emu-nt params="?Yield, ?Await">UnaryExpression</emu-nt></emu-rhs>
+      <ins class="block"><emu-rhs a="unary-expression-await" constraints="+Await"><emu-nt params="?Yield">AwaitExpression</emu-nt></emu-rhs></ins>
     </emu-production>
 
     <emu-note>Currently it is not possible for an |AwaitExpression| and a |YieldExpression| to be parsed together, so technically passing the `?Yield` parameter for <emu-production name="UnaryExpression" class="inline"><emu-rhs constraints="+Await">await <emu-nt params="?Yield, Await">UnaryExpression</emu-nt></emu-rhs></emu-production> is unnecessary. It will probably be useful for AsyncGenerators however.</emu-note>
+
+    <emu-clause id="unary-operators-static-semantics-isfunctiondefinition">
+      <h1>Static Semantics: IsFunctionDefinition</h1>
+      <p>
+        <emu-prodref name="UnaryExpression" a="unary-expression-delete" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-void" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-typeof" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-increment" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-decrement" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-positive" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-negative" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-bitwise-complement" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-logical-complement" class="inline"></emu-prodref><br>
+        <ins><emu-prodref name="UnaryExpression" a="unary-expression-await" class="inline"></emu-prodref></ins>
+      </p>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="unary-operators-static-semantics-isvalidsimpleassignmenttarget">
+      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
+      <p>
+        <emu-prodref name="UnaryExpression" a="unary-expression-delete" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-void" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-typeof" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-increment" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-decrement" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-positive" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-negative" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-bitwise-complement" class="inline"></emu-prodref><br>
+        <emu-prodref name="UnaryExpression" a="unary-expression-logical-complement" class="inline"></emu-prodref><br>
+        <ins><emu-prodref name="UnaryExpression" a="unary-expression-await" class="inline"></emu-prodref></ins>
+      </p>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="MethodDefinition">
@@ -77,30 +166,53 @@
   <emu-clause id="AssignmentExpression">
     <h1>|AssignmentExpression|</h1>
     <emu-production name="AssignmentExpression" params="In, Yield, Await">
-      <emu-rhs><emu-nt params="?In, ?Yield, ?Await">ConditionalExpression</emu-nt></emu-rhs>
-      <emu-rhs constraints="+Yield"><emu-nt params="?In, ?Await">YieldExpression</emu-nt></emu-rhs>
-      <emu-rhs><emu-nt params="?In, ?Yield, ?Await">ArrowFunction</emu-nt></emu-rhs>
-      <ins class="block"><emu-rhs><emu-nt params="?In, ?Yield">AsyncArrowFunction</emu-nt></emu-rhs></ins>
-      <emu-rhs><emu-nt params="?Yield, ?Await">LeftHandSideExpression</emu-nt> = <emu-nt params="?In, ?Yield, ?Await">AssignmentExpression</emu-nt></emu-rhs>
-      <emu-rhs><emu-nt params="?Yield, ?Await">LeftHandSideExpression</emu-nt> <emu-nt>AssignmentOperator</emu-nt> <emu-nt params="?In, ?Yield, ?Await">AssignmentExpression</emu-nt></emu-rhs>
-    </emu-production>
-  </emu-clause>
-
-  <emu-clause id="ConciseBody">
-    <h1>|ConciseBody|</h1>
-    <emu-production name="ConciseBody" params="In, Await">
-      <emu-rhs><emu-gann>lookahead ≠ {</emu-gann> <emu-nt params="?In, ?Await">AssignmentExpression</emu-nt></emu-rhs>
-      <emu-rhs>{ <emu-nt params="?Await">FunctionBody</emu-nt> }</emu-rhs>
+      <emu-rhs a="assignment-expression-conditional"><emu-nt params="?In, ?Yield, ?Await">ConditionalExpression</emu-nt></emu-rhs>
+      <emu-rhs a="assignment-expression-yield" constraints="+Yield"><emu-nt params="?In, ?Await">YieldExpression</emu-nt></emu-rhs>
+      <emu-rhs a="assignment-expression-arrow"><emu-nt params="?In, ?Yield, ?Await">ArrowFunction</emu-nt></emu-rhs>
+      <ins class="block"><emu-rhs a="assignment-expression-async"><emu-nt params="?In, ?Yield, ?Await">AsyncArrowFunction</emu-nt></emu-rhs></ins>
+      <emu-rhs a="assignment-expression-assignment"><emu-nt params="?Yield, ?Await">LeftHandSideExpression</emu-nt> = <emu-nt params="?In, ?Yield, ?Await">AssignmentExpression</emu-nt></emu-rhs>
+      <emu-rhs a="assignment-expression-compound"><emu-nt params="?Yield, ?Await">LeftHandSideExpression</emu-nt> <emu-nt>AssignmentOperator</emu-nt> <emu-nt params="?In, ?Yield, ?Await">AssignmentExpression</emu-nt></emu-rhs>
     </emu-production>
 
-    <emu-note>Await parameter added.</emu-note>
+    <emu-clause id="assignment-operators-static-semantics-isfunctiondefinition">
+      <h1>Static Semantics: IsFunctionDefinition</h1>
+      <p>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-arrow" class="inline"></emu-prodref><br>
+        <ins><emu-prodref name="AssignmentExpression" a="assignment-expression-async" class="inline"></emu-prodref></ins>
+      </p>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <p>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-yield" class="inline"></emu-prodref><br>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-assignment" class="inline"></emu-prodref><br>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-compound" class="inline"></emu-prodref>
+      </p>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="assignment-operators-static-semantics-isvalidsimpleassignmenttarget">
+      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
+      <p>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-yield" class="inline"></emu-prodref><br>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-arrow" class="inline"></emu-prodref><br>
+        <ins><emu-prodref name="AssignmentExpression" a="assignment-expression-async" class="inline"></emu-prodref></ins><br>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-assignment" class="inline"></emu-prodref><br>
+        <emu-prodref name="AssignmentExpression" a="assignment-expression-compound" class="inline"></emu-prodref>
+      </p>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="ExpressionStatement">
     <h1>|ExpressionStatement|</h1>
     <emu-production name="ExpressionStatement" params="Yield, Await">
       <emu-rhs>
-        <emu-gann>lookahead ∉ { <emu-t>{</emu-t>, <emu-t>function</emu-t>, <emu-t>class</emu-t>, <emu-t>let [</emu-t><ins>,<emu-t>async function</emu-t></ins>}</emu-gann>
+        <emu-gann>lookahead ∉ { <emu-t>{</emu-t>, <emu-t>function</emu-t>, <emu-t>class</emu-t>, <emu-t>let [</emu-t><ins>,<emu-t>async</emu-t><emu-gann>no <emu-nt>LineTerminator</emu-nt> here</emu-gann><emu-t>function</emu-t></ins>}</emu-gann>
         <emu-nt params="In, ?Yield, ?Await">Expression</emu-nt>
       </emu-rhs>
     </emu-production>

--- a/spec/syntax.html
+++ b/spec/syntax.html
@@ -6,10 +6,10 @@
 
     AsyncFunctionExpression ::
         `async` [no LineTerminator here] `function` `(` FormalParameters[Await] `)` `{` AsyncFunctionBody `}`                   #1
-        `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters[Await] `)` `{` AsyncFunctionBody `}` #2
+        `async` [no LineTerminator here] `function` BindingIdentifier[Await] `(` FormalParameters[Await] `)` `{` AsyncFunctionBody `}` #2
 
-    AsyncMethod ::
-        `async` [no LineTerminator here] PropertyName `(` StrictFormalParameters[Await] `)` `{` AsyncFunctionBody `}` #1
+    AsyncMethod[Yield, Await] ::
+        `async` [no LineTerminator here] PropertyName[?Yield, ?Await] `(` StrictFormalParameters[Await] `)` `{` AsyncFunctionBody `}` #1
 
     AsyncFunctionBody ::
         FunctionBody[Await] #1
@@ -17,13 +17,13 @@
     AwaitExpression[Yield] ::
         `await` UnaryExpression[?Yield, Await] #1
 
-    AsyncArrowFunction[In, Yield] ::
+    AsyncArrowFunction[In, Yield, Await] ::
         `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In] #1
-        CoverCallExpressionAndAsyncArrowHead[?Yield, Await] [no LineTerminator here] `=>` AsyncConciseBody[?In]                  #2
+        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In]                 #2
 
     AsyncConciseBody[In] ::
-        [lookahead != `{`] AssignmentExpression[?In] #1
-        `{` AsyncFunctionBody `}`                  #2
+        [lookahead != `{`] AssignmentExpression[?In, Await] #1
+        `{` AsyncFunctionBody `}`                           #2
 
     AsyncArrowBindingIdentifier[Yield]
         BindingIdentifier[?Yield, Await] #1
@@ -32,13 +32,13 @@
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await] #1
 </emu-grammar>
 
-<emu-note>`yield` is |Identifier| or |YieldExpression| in |FunctionParameters| of |AsyncFunctionDeclaration| and |AsyncFunctionExpression| and |ArrowParameters| of |AsyncArrowFunction| depending on context. `await` is always parsed as an |AwaitExpression| but is a Syntax Error via static semantics. Yield is always allowed as an identifier of an |AsyncFunctionExpression|.</emu-note>
+<emu-note>`yield` is |Identifier| or |YieldExpression| in |FunctionParameters| of |AsyncFunctionDeclaration| and |AsyncFunctionExpression| and |ArrowParameters| of |AsyncArrowFunction| depending on context. `await` is always parsed as an |AwaitExpression| but is a Syntax Error via static semantics. `yield` is always allowed as an identifier of an |AsyncFunctionExpression|.</emu-note>
 
-<emu-note>Unlike `yield`, it is a Syntax Error to omit the operand of an Await. You must await something.</emu-note>
+<emu-note>Unlike |YieldExpression|, it is a Syntax Error to omit the operand of an |AwaitExpression|. You must await something.</emu-note>
 
 
 <h3>Supplemental Syntax</h3>
-<p>When processing the production <emu-prodref name="AsyncArrowFunction" a="1" class="inline"></emu-prodref> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following gramar:</p>
+<p>When processing the production <emu-prodref name="AsyncArrowFunction" a="2" class="inline"></emu-prodref> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following gramar:</p>
 
 <emu-grammar>
     AsyncArrowHead[?Yield] ::


### PR DESCRIPTION
- `AsyncFunction Awaited Fulfilled` and `AsyncFunction Awaited Rejected` must return something. To keep it simple I've used the value of the resumed computation. 
- `AsyncArrowFunction` changes:
  - `AsyncArrowBindingIdentifier` is used as the parameters production (cf. call to AsyncFunctionCreate), parameters productions need to define BoundNames, ExpectedArgumentCount, IsSimpleParameterList, ContainsExpression and IteratorBindingInitialization (see FunctionDeclarationInstantiation). (Also: Definitions in ES2015 for arrow functions are incorrect - need to file a spec bug.)
  - Remove BoundNames definition, not needed.
  - Add missing LexicallyDeclaredNames, LexicallyScopedDeclarations, VarDeclaredNames and VarScopedDeclarations definitions. ~~It's necessary to define these static semantics for both `AsyncConciseBody` productions; the definitions for `ConciseBody` in ES2015 are incomplete. That's a spec bug, I still need to file an issue for it.~~ (Later: Never mind, I've misread the _chain production_ definition from 5.1.1).
- Add missing SuperCall early errors for AsyncFunctionDeclaration and AsyncFunctionExpression.
- Remove unnecessary HasDirectSuper for AsyncFunctionDeclaration and AsyncFunctionExpression.
- IsConstantDeclaration: Change AsyncFunctionDeclaration to create mutable bindings. (Is this correct?)
- Add missing evaluation semantics for AsyncFunctionExpression.
- Add missing PropertyDefinitionEvaluation semantics for AsyncMethod.
- Add early error restriction for AwaitExpression in ArrowFunction.
- Add early error restrictions for `await` as identifier when [Await] parameter is present. (Is this correct?)
- Add more modified static semantics (IsFunctionDefinition, IsValidSimpleAssignmentTarget).
- And other minor issues.
