### PR TITLE
Change async context set-up

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -13,15 +13,23 @@
   <emu-clause id="abstract-ops-async-function-start" aoid="AsyncFunctionStart">
     <h1>AsyncFunctionStart(promiseCapability, asyncFunctionBody)</h1>
     <emu-alg>
-      1. Let _asyncContext_ be the running execution context.
-      1. Set the PromiseCapability component of _asyncContext_ to _promiseCapability_. <!-- TODO: modify the definition of running execution contexts to contain this -->
-      1. Let _result_ be the result of evaluating _asyncFunctionBody_.
-      1. Assert: once this step is reached, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-      1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-      1. If _result_.[[type]] is ~normal~, let _completionResult_ be Call(_promiseCapability_.[[Resolve]], *undefined*, «*undefined*»).
-      1. Otherwise, if _result_.[[type]] is ~return~, let _completionResult_ be Call(_promiseCapability_.[[Resolve]], *undefined*, «_result_.[[value]]»).
-      1. Otherwise, _result_.[[type]] must be ~throw~. Let _completionResult_ be Call(_promiseCapability_.[[Reject]], *undefined*, «_result_.[[value]]»).
-      1. ReturnIfAbrupt(_completionResult_).
+      1. Let _runningContext_ be the running execution context.
+      1. Let _asyncContext_ be a copy of _runningContext_. <!-- TODO: Probably need to define how to copy an execution context. -->
+      1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+        1. Let _result_ be the result of evaluating _asyncFunctionBody_.
+        1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
+        1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. If _result_.[[type]] is ~normal~, then
+          1. Return Call(_promiseCapability_.[[Resolve]], *undefined*, «*undefined*»).
+        1. Else if _result_.[[type]] is ~return~, then
+          1. Return Call(_promiseCapability_.[[Resolve]], *undefined*, «_result_.[[value]]»).
+        1. Else,
+          1. Assert: _result_.[[type]] is ~throw~.
+          1. Return Call(_promiseCapability_.[[Reject]], *undefined*, «_result_.[[value]]»).
+      1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
+      1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
+      1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
+      1. Return Completion(_result_).
     </emu-alg>
   </emu-clause>
 
@@ -29,7 +37,6 @@
     <h1>AsyncFunctionAwait(value)</h1>
     <emu-alg>
       1. Let _asyncContext_ be the running execution context.
-      1. Assert: _asyncContext_ is the execution context of an async function.
       1. Let _promiseCapability_ be NewPromiseCapability(%Promise%).
       1. Assert: _promiseCapability_ is not an abrupt completion. <!-- TODO: Either remove this assertion or add after every call to NewPromiseCapability(%Promise%). -->
       1. Let _resolveResult_ be Call(_promiseCapability_.[[Resolve]], *undefined*, «_value_»).
@@ -42,7 +49,7 @@
       1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
       1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
         1. Return _resumptionValue_.
-      1. Return *undefined*.
+      1. Return NormalCompletion(*undefined*).
     </emu-alg>
 
      <!-- could factor out the first four steps into something like "let _resolveResult_ be PromiseCoerce(_value_)" that is guaranteed to never throw -->

--- a/spec/arrows.html
+++ b/spec/arrows.html
@@ -85,10 +85,6 @@
     <emu-alg>
       1. Return an empty List.
     </emu-alg>
-    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return LexicallyDeclaredNames of |AsyncFunctionBody|.
-    </emu-alg>
   </emu-clause>
 
   <emu-clause id="async-arrows-static-semantics-LexicallyScopedDeclarations">
@@ -96,10 +92,6 @@
     <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
     <emu-alg>
       1. Return an empty List.
-    </emu-alg>
-    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return LexicallyScopedDeclarations of |AsyncFunctionBody|.
     </emu-alg>
   </emu-clause>
 
@@ -109,10 +101,6 @@
     <emu-alg>
       1. Return an empty List.
     </emu-alg>
-    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return VarDeclaredNames of |AsyncFunctionBody|.
-    </emu-alg>
   </emu-clause>
 
   <emu-clause id="async-arrows-static-semantics-VarScopedDeclarations">
@@ -120,10 +108,6 @@
     <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
     <emu-alg>
       1. Return an empty List.
-    </emu-alg>
-    <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
-    <emu-alg>
-      1. Return VarScopedDeclarations of |AsyncFunctionBody|.
     </emu-alg>
   </emu-clause>
 
@@ -152,7 +136,8 @@
     <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
     <emu-alg>
       1. Let _promiseCapability_ be NewPromiseCapability(%Promise%).
-      1. Perform AsyncFunctionStart(_promiseCapability_, _FunctionBody_).
+      1. Let _result_ be AsyncFunctionStart(_promiseCapability_, _FunctionBody_).
+      1. ReturnIfAbrupt(_result_).
       1. Return Completion{[[type]]: ~return~, [[value]]: _promiseCapability_.[[Promise]], [[target]]: ~empty~}.
     </emu-alg>
     <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>

--- a/spec/declarations-and-expressions.html
+++ b/spec/declarations-and-expressions.html
@@ -110,7 +110,8 @@
     </p>
     <emu-alg>
       1. Let _promiseCapability_ be NewPromiseCapability(%Promise%).
-      1. Perform AsyncFunctionStart(_promiseCapability_, _FunctionBody_).
+      1. Let _result_ be AsyncFunctionStart(_promiseCapability_, _FunctionBody_).
+      1. ReturnIfAbrupt(_result_).
       1. Return Completion{[[type]]: ~return~, [[value]]: _promiseCapability_.[[Promise]], [[target]]: ~empty~}.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
This commit also removes unneeded static semantics I've introduced in #56. I've misread the _chain production_ definition from 5.1.1 (Context-Free Grammars) and mistakenly assumed "_[...] exactly one nonterminal symbol on its right-hand side [...]_" includes alternative productions.
