### PR TITLE
update async generator syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The introduction of Promises and Generators in ECMAScript presents an opportunit
 
 This proposal is implemented in a [regenerator](https://github.com/facebook/regenerator) which can compile ES5 code containing `async` and `await` down to vanilla ES5 to run in existing browsers and runtimes.
 
-This repo contains a complete example using a large number of the features of the proposal.  To run this example:
+This repo contains a complete example using a large number of the features of the proposal.  To run this example:(Currently it's not work because changes in GitHub API.)
 
 ```Shell
 npm install

--- a/server.asyncawait.js
+++ b/server.asyncawait.js
@@ -27,13 +27,13 @@ http.createServer(async function (req, res) {
             // promise-returning async HTTP GET
             var res = await request({url: url, headers: headers});
             var items = JSON.parse(res.body).items;
-            // nested parallel work is still possible with await* ( or `await Promise.all`)
-            var newItems = await* items.map(async function (item) { 
+            // nested parallel work is still possible with `await Promise.all`
+            var newItems = await Promise.all(items.map(async function (item) {
                 return {
                     full_name: item.full_name, 
                     collabs_images: await getCollaboratorImages(item.full_name)
                }
-            });
+            }));
             results = results.concat(newItems);
             url = (/<(.*)>; rel="next"/.exec(res.headers.link) || [])[1];
             // break once there is no 'next' link


### PR DESCRIPTION
`async *` is not valid in the spec.
Also update README since example does not work due to GitHub's API change.

resolve #85 
